### PR TITLE
fix: use new environment file GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
     run: |
       DADJOKE=$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/)
       echo "$DADJOKE"
-      echo "::set-output name=joke::$DADJOKE"
+      echo "joke=$DADJOKE" >> $GITHUB_OUTPUT
     shell: bash
 branding:
   icon: 'award'

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,9 @@ runs:
     run: |
       DADJOKE=$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/)
       echo "$DADJOKE"
-      echo "joke=$DADJOKE" >> $GITHUB_OUTPUT
+      echo "joke<<EOF" >> $GITHUB_OUTPUT
+      echo "$DADJOKE" >> $GITHUB_OUTPUT
+      echo "EOF" >> $GITHUB_OUTPUT
     shell: bash
 branding:
   icon: 'award'


### PR DESCRIPTION
Hey,
I've started using your github action but got following warning:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

so here is quick fix for deprecated part ; )